### PR TITLE
Adding reload command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Of course, manually formatting files is for people who aren't lazy. So, by defau
 ```vim
 let g:clj_fmt_autosave = 0
 ```
+Occasionally vim-cljfmt might need to be reloaded (for example, if the fireplace REPL connection is reset). Reload vim-cljfmt with the following:
+
+```vim
+:CljfmtRequire
+```
 
 ## Installation
 

--- a/doc/cljfmt.txt
+++ b/doc/cljfmt.txt
@@ -51,6 +51,9 @@ COMMANDS                                                   *cljfmt-commands*
 :Cljfmt                                                            *:Cljfmt*
   Format the current file.
 
+:CljfmtRequire
+  Reload vim-cljfmt (needed if fireplace REPL connection is reset)
+
 ==============================================================================
 CONTRIBUTIONS                                         *cljfmt-contributions*
 

--- a/doc/cljfmt.txt
+++ b/doc/cljfmt.txt
@@ -52,7 +52,7 @@ COMMANDS                                                   *cljfmt-commands*
   Format the current file.
 
 :CljfmtRequire
-  Reload vim-cljfmt (needed if fireplace REPL connection is reset)
+  Reload vim-cljfmt (this may be needed if REPL connection is reset).
 
 ==============================================================================
 CONTRIBUTIONS                                         *cljfmt-contributions*

--- a/plugin/cljfmt.vim
+++ b/plugin/cljfmt.vim
@@ -86,3 +86,4 @@ augroup vim-cljfmt
 augroup END
 
 command! Cljfmt call cljfmt#Format()
+command! CljfmtRequire call s:RequireCljfmt()


### PR DESCRIPTION
I love vim-cljfmt! 

One problem I've run into is that :Cljfmt stops having an effect when I reset fireplace's REPL connection. I've found it helpful to add a :CljfmtRequire command which reloads vim-cljfmt into the REPL.
