### PR TITLE
fix l:cljfmt_output error by ending the redir

### DIFF
--- a/plugin/cljfmt.vim
+++ b/plugin/cljfmt.vim
@@ -56,6 +56,9 @@ function! s:GetFormattedFile()
     catch /^Clojure:.*/
         redir END
         return s:GetReformatString()
+    catch
+      redir END
+      throw v:exception
     endtry
     redir END
     return s:FilterOutput(split(l:cljfmt_output, "\n"))


### PR DESCRIPTION
I was experiencing the same message in git-gutter as #7 and #6 when fireplace was disconnected. This seems to silence the error.
