### PR TITLE
Fail gracefully when reformat-string fails

### DIFF
--- a/plugin/cljfmt.vim
+++ b/plugin/cljfmt.vim
@@ -53,7 +53,8 @@ function! s:GetFormattedFile()
         silent! call fireplace#session_eval(s:GetReformatString(l:bufcontents))
     catch /^Clojure:.*/
         redir END
-        return s:GetReformatString()
+        " real error msg is here
+        throw l:cljfmt_output
     catch
       redir END
       throw v:exception
@@ -73,8 +74,15 @@ function! cljfmt#Format()
         " save cursor position and many other things
         let l:curw = winsaveview()
 
-        let formatted_output = s:GetFormattedFile()
-        :0,substitute/\_.*/\=formatted_output/g
+        try
+            let formatted_output = s:GetFormattedFile()
+            :0,substitute/\_.*/\=formatted_output/g
+        catch
+            echohl ErrorMsg
+            echomsg "Failed to format file:"
+            echomsg v:exception
+            echohl None
+        endtry
 
         " restore our cursor/windows positions
         call winrestview(l:curw)


### PR DESCRIPTION
Hello, this is an awesome plugin btw.

I have noticed that when I call the `Cljfmt`on a file that has a syntax error it barfs with a not very helpful error message.

I believe it is because, in the vimscript, it is trying to call `s:GetReformatString()` with an empty argument list. Is this the intended behaviour?

My vimscript is very poor, but I was playing around with `fireplace#session_eval` and apparently the `reformat-string` error result is contained in the `l:cljfmt_output` var. 
I have tried to fix it, but I did not manage to display a nice error message in the end.
