### PR TITLE
Always require Cljfmt.

### DIFF
--- a/plugin/cljfmt.vim
+++ b/plugin/cljfmt.vim
@@ -63,9 +63,7 @@ function! s:GetFormattedFile()
 endfunction
 
 function! cljfmt#Format()
-    if !g:clj_fmt_required
-        let g:clj_fmt_required = s:RequireCljfmt()
-    endif
+	let g:clj_fmt_required = s:RequireCljfmt()
 
     " If cljfmt.core has already been required, or was successfully imported
     " above


### PR DESCRIPTION
Attempt to fix issue #28 by removing the check to see if Cljfmt has
already been required.