### PR TITLE
added missing endif clause

### DIFF
--- a/plugin/cljfmt.vim
+++ b/plugin/cljfmt.vim
@@ -134,6 +134,7 @@ function! s:CljfmtRange(bang, line1, line2, count, args) abort
     if !line1 || !line2
       return ''
     endif
+  endif
     let expr = getline(line1)[col1-1 : -1] . "\n"
             \ . join(map(getline(line1+1, line2-1), 'v:val . "\n"'))
             \ . getline(line2)[0 : col2-1]


### PR DESCRIPTION
i was having problem making `clj_fmt_autosave` option to work. when i opened the plugin file, my vimscript linter warned about the missing endif. When i put it in place, the option started to work.